### PR TITLE
feat: implement admin panel layout utilities

### DIFF
--- a/app/admin/hooks/useAdminGate.ts
+++ b/app/admin/hooks/useAdminGate.ts
@@ -2,28 +2,45 @@
 
 import { useEffect, useState } from 'react'
 
+export type AdminGateStatus = 'checking' | 'granted' | 'denied'
+
+const STORAGE_KEY = 'admin_ok'
+
 export function useAdminGate(pinEnv?: string) {
-  const PIN = pinEnv || process.env.NEXT_PUBLIC_ADMIN_PIN || 'admin123'
-  const [ok, setOk] = useState(false)
+  const pin = pinEnv || process.env.NEXT_PUBLIC_ADMIN_PIN || 'admin123'
+  const [status, setStatus] = useState<AdminGateStatus>('checking')
+  const [pinInput, setPinInput] = useState('')
 
   useEffect(() => {
     if (typeof window === 'undefined') return
-    if (localStorage.getItem('admin_ok') === '1') setOk(true)
+    const stored = localStorage.getItem(STORAGE_KEY)
+    setStatus(stored === '1' ? 'granted' : 'denied')
   }, [])
 
-  function check(input: string) {
-    if (input === PIN) {
-      localStorage.setItem('admin_ok', '1')
-      setOk(true)
+  const tryEnter = (value?: string) => {
+    const attempt = value ?? pinInput
+    if (attempt === String(pin)) {
+      localStorage.setItem(STORAGE_KEY, '1')
+      setStatus('granted')
       return true
     }
+    setStatus('denied')
     return false
   }
 
-  function logout() {
-    localStorage.removeItem('admin_ok')
-    setOk(false)
+  const logout = () => {
+    localStorage.removeItem(STORAGE_KEY)
+    setStatus('denied')
+    setPinInput('')
   }
 
-  return { ok, check, logout, PIN }
+  return {
+    pin,
+    status,
+    granted: status === 'granted',
+    pinInput,
+    setPinInput,
+    tryEnter,
+    logout,
+  }
 }

--- a/app/admin/hooks/useTheme.ts
+++ b/app/admin/hooks/useTheme.ts
@@ -3,26 +3,66 @@
 import { useEffect, useState } from 'react'
 
 export type Theme = 'light' | 'dark'
+const STORAGE_KEY = 'theme'
+
+function resolveInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light'
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY) as Theme | null
+    if (stored === 'light' || stored === 'dark') return stored
+    const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches
+    return prefersDark ? 'dark' : 'light'
+  } catch {
+    return 'light'
+  }
+}
+
+function applyTheme(next: Theme) {
+  if (typeof document === 'undefined') return
+  const root = document.documentElement
+  root.classList.toggle('dark', next === 'dark')
+  root.style.setProperty('--background', next === 'dark' ? '#0f1729' : '#f8fafc')
+  root.style.setProperty('--foreground', next === 'dark' ? '#e2e8f0' : '#0f172a')
+  try {
+    localStorage.setItem(STORAGE_KEY, next)
+  } catch {}
+}
 
 export function useTheme() {
-  const [theme, setTheme] = useState<Theme>('light')
+  const [theme, setTheme] = useState<Theme>(() => resolveInitialTheme())
 
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem('theme') as Theme | null
-      const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches
-      const init = stored ?? (prefersDark ? 'dark' : 'light')
-      setTheme(init)
-      document.documentElement.classList.toggle('dark', init === 'dark')
-    } catch {}
+    applyTheme(theme)
+  }, [theme])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = () => {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY)
+        if (stored) return
+      } catch {
+        /* ignore */
+      }
+      setTheme(media.matches ? 'dark' : 'light')
+    }
+    media.addEventListener('change', onChange)
+    return () => media.removeEventListener('change', onChange)
   }, [])
 
-  function toggle() {
-    const next = theme === 'dark' ? 'light' : 'dark'
-    setTheme(next)
-    document.documentElement.classList.toggle('dark', next === 'dark')
-    localStorage.setItem('theme', next)
-  }
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY && (event.newValue === 'light' || event.newValue === 'dark')) {
+        setTheme(event.newValue)
+      }
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [])
 
-  return { theme, toggle }
+  const toggle = () => setTheme(current => (current === 'dark' ? 'light' : 'dark'))
+
+  return { theme, setTheme, toggle }
 }

--- a/app/admin/hooks/useToasts.ts
+++ b/app/admin/hooks/useToasts.ts
@@ -2,17 +2,43 @@
 
 import { useCallback } from 'react'
 
-const BUS = typeof window !== 'undefined' ? window : ({} as any)
-const EVT = 'app:toast'
+export type ToastKind = 'success' | 'error' | 'info'
+export type ToastPayload = {
+  id: string
+  type: ToastKind
+  message: string
+}
 
-function push(type: 'success'|'error'|'info', message: string) {
-  const id = Math.random().toString(36).slice(2)
-  BUS.dispatchEvent?.(new CustomEvent(EVT, { detail: { id, type, message }}))
+export const TOAST_EVENT = 'admin:toast'
+
+function getBus(): Window | null {
+  if (typeof window === 'undefined') return null
+  return window
+}
+
+function emitToast(payload: ToastPayload) {
+  const bus = getBus()
+  if (!bus) return
+  bus.dispatchEvent(new CustomEvent(TOAST_EVENT, { detail: payload }))
+}
+
+function createPayload(type: ToastKind, message: string): ToastPayload {
+  return {
+    id: Math.random().toString(36).slice(2),
+    type,
+    message,
+  }
 }
 
 export function useToasts() {
-  const success = useCallback((m: string)=> push('success', m), [])
-  const error   = useCallback((m: string)=> push('error', m), [])
-  const info    = useCallback((m: string)=> push('info', m), [])
-  return { success, error, info }
+  const toast = useCallback((type: ToastKind, message: string) => emitToast(createPayload(type, message)), [])
+  const success = useCallback((message: string) => toast('success', message), [toast])
+  const error = useCallback((message: string) => toast('error', message), [toast])
+  const info = useCallback((message: string) => toast('info', message), [toast])
+
+  return { toast, success, error, info }
+}
+
+export function showToast(type: ToastKind, message: string) {
+  emitToast(createPayload(type, message))
 }

--- a/app/admin/hooks/useTurnos.ts
+++ b/app/admin/hooks/useTurnos.ts
@@ -1,40 +1,50 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { TurnoAdmin } from '../lib/types'
 import { hmLocalToMinutes } from '../lib/date'
-import { postJSON } from '../../lib/api'
+import type { TurnoAdmin, TurnoFilters, TurnoKpiResumen } from '../lib/types'
+import { getTurnosDelDia } from '../lib/fetchers'
 
-export function useTurnos(fecha: string, estado: string, vehType: string) {
+export function useTurnos(filters: TurnoFilters) {
+  const { fecha, estado = 'todos', tipoVehiculo = 'todos' } = filters
   const [turnos, setTurnos] = useState<TurnoAdmin[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const cargar = useCallback(async () => {
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
     try {
-      setLoading(true); setError(null)
-      const data = await postJSON<TurnoAdmin[]>('/api/turnos/dia', { fecha })
-      let lista = data
-      if (estado !== 'todos') lista = lista.filter(t => (t.estado || '').toLowerCase() === estado)
-      if (vehType !== 'todos') lista = lista.filter(t => (t.tipo_vehiculo_turno || '').toUpperCase() === vehType)
-      lista.sort((a, b) => hmLocalToMinutes(a.hora) - hmLocalToMinutes(b.hora))
-      setTurnos(lista)
-    } catch (e:any) {
-      setError(e.message || 'No fue posible cargar los turnos.')
+      let data = await getTurnosDelDia(fecha)
+      if (estado !== 'todos') {
+        data = data.filter(turno => (turno.estado ?? '').toLowerCase() === estado)
+      }
+      if (tipoVehiculo !== 'todos') {
+        data = data.filter(turno => (turno.tipo_vehiculo_turno ?? '').toUpperCase() === tipoVehiculo)
+      }
+      data.sort((a, b) => hmLocalToMinutes(a.hora) - hmLocalToMinutes(b.hora))
+      setTurnos(data)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'No fue posible cargar los turnos.'
+      setError(message)
       setTurnos([])
-    } finally { setLoading(false) }
-  }, [fecha, estado, vehType])
+    } finally {
+      setLoading(false)
+    }
+  }, [fecha, estado, tipoVehiculo])
 
-  useEffect(() => { cargar() }, [cargar])
+  useEffect(() => {
+    void load()
+  }, [load])
 
-  const kpis = useMemo(() => {
-    const total        = turnos.length
-    const confirmado   = turnos.filter(t => (t.estado||'').toLowerCase()==='confirmado').length
-    const pendiente    = turnos.filter(t => (t.estado||'').toLowerCase()==='pendiente').length
-    const cancelado    = turnos.filter(t => (t.estado||'').toLowerCase()==='cancelado').length
-    const finalizado   = turnos.filter(t => (t.estado||'').toLowerCase()==='finalizado').length
+  const kpis: TurnoKpiResumen = useMemo(() => {
+    const total = turnos.length
+    const confirmado = turnos.filter(t => (t.estado ?? '').toLowerCase() === 'confirmado').length
+    const pendiente = turnos.filter(t => (t.estado ?? '').toLowerCase() === 'pendiente').length
+    const cancelado = turnos.filter(t => (t.estado ?? '').toLowerCase() === 'cancelado').length
+    const finalizado = turnos.filter(t => (t.estado ?? '').toLowerCase() === 'finalizado').length
     return { total, confirmado, pendiente, cancelado, finalizado }
   }, [turnos])
 
-  return { turnos, loading, error, kpis, refetch: cargar }
+  return { turnos, loading, error, kpis, refetch: load }
 }

--- a/app/admin/layout/AdminLayout.tsx
+++ b/app/admin/layout/AdminLayout.tsx
@@ -2,28 +2,29 @@
 
 import React from 'react'
 import AdminTopbar from './AdminTopbar'
+import { Toaster } from '../ui/Toasts'
 
-type Props = {
+export type AdminLayoutProps = {
   sidebar?: React.ReactNode
   topbarRight?: React.ReactNode
   children: React.ReactNode
+  className?: string
 }
 
-export default function AdminLayout({ sidebar, topbarRight, children }: Props) {
+export default function AdminLayout({
+  sidebar,
+  topbarRight,
+  children,
+  className = '',
+}: AdminLayoutProps) {
   return (
-    <div className="min-h-screen bg-[--background] text-[--foreground]">
+    <div className={`min-h-screen bg-[--background] text-[--foreground] transition-colors duration-200 ${className}`.trim()}>
       <AdminTopbar right={topbarRight} />
-      <div className="max-w-[1400px] mx-auto grid grid-cols-12 gap-4 px-3 py-4">
-        {/* Sidebar rail */}
-        <aside className="col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-3">
-          {sidebar}
-        </aside>
-
-        {/* Main */}
-        <main className="col-span-12 md:col-span-8 lg:col-span-9">
-          {children}
-        </main>
+      <div className="mx-auto grid max-w-[1400px] grid-cols-12 gap-4 px-3 py-4 sm:px-4">
+        <aside className="col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-3">{sidebar}</aside>
+        <main className="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-9 space-y-4">{children}</main>
       </div>
+      <Toaster />
     </div>
   )
 }

--- a/app/admin/layout/AdminTopbar.tsx
+++ b/app/admin/layout/AdminTopbar.tsx
@@ -3,21 +3,27 @@
 import React from 'react'
 import ThemeToggle from './ThemeToggle'
 
-type Props = {
+export type AdminTopbarProps = {
   title?: string
   right?: React.ReactNode
   className?: string
 }
 
-export default function AdminTopbar({ title = 'Panel administrativo', right, className }: Props) {
+export default function AdminTopbar({
+  title = 'Panel administrativo',
+  right,
+  className = '',
+}: AdminTopbarProps) {
   return (
-    <div className={`sticky top-0 z-40 bg-white dark:bg-slate-900/80 backdrop-blur border-b border-slate-200 dark:border-slate-800 px-3 sm:px-4 py-2 flex items-center gap-2 ${className||''}`}>
-      <div className="font-semibold text-slate-900 dark:text-slate-100 truncate">{title}</div>
-      <div className="ml-auto flex items-center gap-2">
-        {right}
-        {/* Fallback: si no pasan right, mostramos el ThemeToggle */}
-        {!right && <ThemeToggle />}
+    <header
+      className={`sticky top-0 z-40 flex items-center gap-2 border-b border-slate-200 bg-white/90 px-3 py-2 backdrop-blur dark:border-slate-800 dark:bg-slate-950/70 sm:px-4 ${className}`.trim()}
+    >
+      <div className="truncate text-base font-semibold text-slate-900 dark:text-slate-100">
+        {title}
       </div>
-    </div>
+      <div className="ml-auto flex items-center gap-2">
+        {right ?? <ThemeToggle />}
+      </div>
+    </header>
   )
 }

--- a/app/admin/layout/ThemeToggle.tsx
+++ b/app/admin/layout/ThemeToggle.tsx
@@ -1,48 +1,23 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-
-function applyTheme(next: 'light' | 'dark') {
-  const root = document.documentElement
-  if (next === 'dark') root.classList.add('dark')
-  else root.classList.remove('dark')
-  localStorage.setItem('theme', next)
-}
-
-function getInitialTheme(): 'light' | 'dark' {
-  try {
-    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null
-    if (stored === 'light' || stored === 'dark') return stored
-    const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches
-    return prefersDark ? 'dark' : 'light'
-  } catch { return 'light' }
-}
+import { useTheme } from '../hooks/useTheme'
 
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light')
-
-  useEffect(() => {
-    const initial = getInitialTheme()
-    setTheme(initial)
-    applyTheme(initial)
-  }, [])
-
-  const toggle = () => {
-    const next = theme === 'dark' ? 'light' : 'dark'
-    setTheme(next)
-    applyTheme(next)
-  }
+  const { theme, toggle } = useTheme()
+  const isDark = theme === 'dark'
 
   return (
     <button
       type="button"
       onClick={toggle}
-      aria-pressed={theme === 'dark'}
-      title={theme === 'dark' ? 'Cambiar a claro' : 'Cambiar a oscuro'}
-      className="inline-flex items-center gap-2 rounded-xl border border-slate-300 dark:border-slate-600 px-3 py-1.5 text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+      aria-pressed={isDark}
+      aria-label={isDark ? 'Cambiar a tema claro' : 'Cambiar a tema oscuro'}
+      className="inline-flex items-center gap-2 rounded-xl border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
     >
-      <span className="inline-block h-4 w-4">{theme === 'dark' ? '🌙' : '☀️'}</span>
-      <span className="hidden sm:inline">{theme === 'dark' ? 'Oscuro' : 'Claro'}</span>
+      <span className="text-lg" aria-hidden>
+        {isDark ? '🌙' : '☀️'}
+      </span>
+      <span className="hidden sm:inline">{isDark ? 'Oscuro' : 'Claro'}</span>
     </button>
   )
 }

--- a/app/admin/lib/date.ts
+++ b/app/admin/lib/date.ts
@@ -1,38 +1,33 @@
-/** Fecha hoy en Bogotá -> YYYY-MM-DD (en-CA) */
+import { utcTimeToLocalHM as tzUtcTimeToLocalHM } from '../../lib/tz'
+
 export function hoyISO() {
   return new Intl.DateTimeFormat('en-CA', {
     timeZone: 'America/Bogota',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-  }).format(new Date());
+  }).format(new Date())
 }
 
-export function fmtFechaY(esISO: string) {
+export function fmtFechaY(iso: string) {
   try {
     return new Intl.DateTimeFormat('es-ES', {
       timeZone: 'America/Bogota',
       day: '2-digit',
       month: 'short',
-      year: 'numeric'
-    }).format(new Date(esISO))
-  } catch { return esISO }
+      year: 'numeric',
+    }).format(new Date(iso))
+  } catch {
+    return iso
+  }
 }
 
-/** Normaliza a "HH:mm" local Bogotá */
-export function utcTimeToLocalHM(utcOrHM: string): string {
-  // si ya parece HH:mm, devuélvelo
-  if (/^\d{2}:\d{2}$/.test(utcOrHM)) return utcOrHM
-  const d = new Date(utcOrHM)
-  // Bogotá UTC-5 sin DST
-  const H = (d.getUTCHours() - 5 + 24) % 24
-  const M = d.getUTCMinutes()
-  const hh = String(H).padStart(2,'0')
-  const mm = String(M).padStart(2,'0')
-  return `${hh}:${mm}`
+export function utcTimeToLocalHM(value: string) {
+  return tzUtcTimeToLocalHM(value)
 }
 
-/** Convierte HH:mm a minutos desde 00:00 (usado para ordenar) */
-export function hmLocalToMinutes(utcOrHM: string): number {
-  const hm = utcTimeToLocalHM(utcOrHM);
-  const [H, M] = hm.split
+export function hmLocalToMinutes(value: string): number {
+  const hm = utcTimeToLocalHM(value)
+  const [hours, minutes] = hm.split(':').map(number => parseInt(number, 10))
+  return (hours || 0) * 60 + (minutes || 0)
+}

--- a/app/admin/lib/fetchers.ts
+++ b/app/admin/lib/fetchers.ts
@@ -1,1 +1,37 @@
-'"$@"'
+import { postJSON } from '../../lib/api'
+import type { TurnoAdmin } from './types'
+
+export async function getTurnosDelDia(fecha: string): Promise<TurnoAdmin[]> {
+  return postJSON<TurnoAdmin[]>('/api/turnos/dia', { fecha })
+}
+
+export type CrearTurnoPayload = {
+  fecha: string
+  hora: string
+  conductorId?: number
+  tipo_turno?: string | null
+  tipo_vehiculo_turno?: string | null
+  operacion?: string | null
+}
+
+export async function crearTurnoManual(payload: CrearTurnoPayload) {
+  return postJSON('/api/turnos/crear-manual', payload)
+}
+
+export type ActualizarTurnoPayload = {
+  turnoId: number
+  fecha?: string
+  hora?: string
+  estado?: string
+  tipo_turno?: string | null
+  tipo_vehiculo_turno?: string | null
+  operacion?: string | null
+}
+
+export async function actualizarTurno(payload: ActualizarTurnoPayload) {
+  return postJSON('/api/turnos/modificar', payload)
+}
+
+export async function cancelarTurno(turnoId: number) {
+  return postJSON('/api/turnos/cancelar', { turnoId })
+}

--- a/app/admin/lib/types.ts
+++ b/app/admin/lib/types.ts
@@ -1,7 +1,7 @@
 export type TurnoAdmin = {
   id: number
-  fecha: string | any
-  hora: string | any
+  fecha: string
+  hora: string
   estado: string
   tipo_turno: string | null
   operacion?: string | null
@@ -11,8 +11,22 @@ export type TurnoAdmin = {
     cedula?: string
     nombre?: string
     telefono?: string
-  }
+  } | null
+}
+
+export type TurnoFilters = {
+  fecha: string
+  estado?: typeof ESTADOS[number]
+  tipoVehiculo?: typeof VEH_TYPES[number] | 'todos'
+}
+
+export type TurnoKpiResumen = {
+  total: number
+  confirmado: number
+  pendiente: number
+  cancelado: number
+  finalizado: number
 }
 
 export const ESTADOS = ['todos', 'pendiente', 'confirmado', 'en_proceso', 'cancelado', 'finalizado'] as const
-export const VEH_TYPES = ['SEN', 'TM', 'CB', 'DLL', 'XL', 'MM'] as const
+export const VEH_TYPES = ['todos', 'SEN', 'TM', 'CB', 'DLL', 'XL', 'MM'] as const

--- a/app/admin/ui/BadgeEstado.tsx
+++ b/app/admin/ui/BadgeEstado.tsx
@@ -2,13 +2,19 @@
 
 import React from 'react'
 
+const ESTADO_STYLES: Record<string, string> = {
+  confirmado: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+  pendiente: 'bg-amber-50 text-amber-700 ring-amber-200',
+  en_proceso: 'bg-sky-50 text-sky-700 ring-sky-200',
+  cancelado: 'bg-rose-50 text-rose-700 ring-rose-200',
+  finalizado: 'bg-slate-100 text-slate-700 ring-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700',
+}
+
 export default function BadgeEstado({ estado }: { estado?: string | null }) {
-  const e = (estado || '').toLowerCase()
-  let cls = 'bg-gray-100 text-gray-700 ring-1 ring-gray-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700'
-  if (e === 'confirmado')  cls = 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
-  if (e === 'pendiente')   cls = 'bg-amber-50 text-amber-700 ring-1 ring-amber-200'
-  if (e === 'en_proceso')  cls = 'bg-sky-50 text-sky-700 ring-1 ring-sky-200'
-  if (e === 'cancelado')   cls = 'bg-rose-50 text-rose-700 ring-1 ring-rose-200'
-  if (e === 'finalizado')  cls = 'bg-slate-100 text-slate-700 ring-1 ring-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-700'
-  return <span className={`px-2 py-1 rounded-full text-xs ${cls}`}>{e ? e.charAt(0).toUpperCase()+e.slice(1) : ''}</span>
+  const key = (estado ?? '').toLowerCase()
+  const base = 'inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold ring-1'
+  const fallback = 'bg-gray-100 text-gray-700 ring-gray-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700'
+  const label = key ? key.replace(/_/g, ' ') : ''
+
+  return <span className={`${base} ${ESTADO_STYLES[key] ?? fallback}`}>{label ? label.charAt(0).toUpperCase() + label.slice(1) : ''}</span>
 }

--- a/app/admin/ui/Buttons.tsx
+++ b/app/admin/ui/Buttons.tsx
@@ -2,34 +2,55 @@
 
 import React from 'react'
 
-type BtnProps = React.ButtonHTMLAttributes<HTMLButtonElement> & { as?: 'button' }
-const base = 'px-3 py-1.5 rounded-lg font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition'
+export type ButtonVariant =
+  | 'primary'
+  | 'success'
+  | 'sky'
+  | 'danger'
+  | 'secondary'
+  | 'icon'
 
-export function PrimaryButton(props: BtnProps) {
-  const { className, ...rest } = props
-  return <button className={`${base} bg-indigo-600 hover:bg-indigo-700 text-white ${className||''}`} {...rest} />
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Exclude<ButtonVariant, 'icon'>
 }
-export function SuccessButton(props: BtnProps) {
-  const { className, ...rest } = props
-  return <button className={`${base} bg-emerald-600 hover:bg-emerald-700 text-white ${className||''}`} {...rest} />
+
+const base = 'inline-flex items-center justify-center gap-2 rounded-lg px-3 py-1.5 text-sm font-semibold transition disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-indigo-500 dark:focus-visible:ring-offset-slate-950'
+
+function compose(variant: ButtonVariant, className?: string) {
+  const styles: Record<ButtonVariant, string> = {
+    primary: 'bg-indigo-600 text-white hover:bg-indigo-700',
+    success: 'bg-emerald-600 text-white hover:bg-emerald-700',
+    sky: 'bg-sky-600 text-white hover:bg-sky-700',
+    danger: 'bg-rose-600 text-white hover:bg-rose-700',
+    secondary:
+      'border border-slate-200 bg-white text-slate-800 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800',
+    icon:
+      'h-10 w-10 border border-slate-200 bg-white text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800',
+  }
+  const extra = className ? ` ${className}` : ''
+  return `${base} ${styles[variant]}${extra}`.trim()
 }
-export function SkyButton(props: BtnProps) {
-  const { className, ...rest } = props
-  return <button className={`${base} bg-sky-600 hover:bg-sky-700 text-white ${className||''}`} {...rest} />
+
+export function PrimaryButton({ className, ...rest }: ButtonProps) {
+  return <button className={compose('primary', className)} {...rest} />
 }
-export function DangerButton(props: BtnProps) {
-  const { className, ...rest } = props
-  return <button className={`${base} bg-rose-600 hover:bg-rose-700 text-white ${className||''}`} {...rest} />
+
+export function SuccessButton({ className, ...rest }: ButtonProps) {
+  return <button className={compose('success', className)} {...rest} />
 }
-export function SecondaryButton(props: BtnProps) {
-  const { className, ...rest } = props
-  return <button className={`${base} bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800 ${className||''}`} {...rest} />
+
+export function SkyButton({ className, ...rest }: ButtonProps) {
+  return <button className={compose('sky', className)} {...rest} />
 }
-export function IconButton({ className, ...rest }: BtnProps) {
-  return (
-    <button
-      className={`w-10 h-10 rounded-lg bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 flex items-center justify-center text-lg ${className||''}`}
-      {...rest}
-    />
-  )
+
+export function DangerButton({ className, ...rest }: ButtonProps) {
+  return <button className={compose('danger', className)} {...rest} />
+}
+
+export function SecondaryButton({ className, ...rest }: ButtonProps) {
+  return <button className={compose('secondary', className)} {...rest} />
+}
+
+export function IconButton({ className, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return <button className={compose('icon', className)} {...rest} />
 }

--- a/app/admin/ui/Card.tsx
+++ b/app/admin/ui/Card.tsx
@@ -2,21 +2,23 @@
 
 import React from 'react'
 
-type Props = {
+export type CardProps = {
   title: string
   extra?: React.ReactNode
   className?: string
   children: React.ReactNode
 }
 
-export default function Card({ title, extra, className, children }: Props) {
+export default function Card({ title, extra, className = '', children }: CardProps) {
   return (
-    <div className={`bg-white dark:bg-slate-900 rounded-2xl border border-slate-200 dark:border-slate-800 overflow-hidden ${className||''}`}>
-      <div className="px-4 py-3 border-b border-slate-100 dark:border-slate-800 flex items-center justify-between">
-        <div className="font-semibold">{title}</div>
+    <section
+      className={`overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900 ${className}`.trim()}
+    >
+      <header className="flex items-center justify-between border-b border-slate-100 px-4 py-3 dark:border-slate-800">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">{title}</h2>
         {extra && <div className="text-xs text-slate-500 dark:text-slate-400">{extra}</div>}
-      </div>
-      <div className="p-2 sm:p-3">{children}</div>
-    </div>
+      </header>
+      <div className="p-3 sm:p-4">{children}</div>
+    </section>
   )
 }

--- a/app/admin/ui/DropdownMore.tsx
+++ b/app/admin/ui/DropdownMore.tsx
@@ -2,41 +2,63 @@
 
 import React, { useEffect, useRef, useState } from 'react'
 
-type Item = { label: string; onClick: ()=>void; disabled?: boolean }
-type Props = { items: Item[]; title?: string }
+export type DropdownItem = {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+}
 
-export default function DropdownMore({ items, title='Más acciones' }: Props) {
+export type DropdownMoreProps = {
+  items: DropdownItem[]
+  title?: string
+}
+
+export default function DropdownMore({ items, title = 'Más acciones' }: DropdownMoreProps) {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    function onDoc(e: MouseEvent) {
+    function handleClick(event: MouseEvent) {
       if (!ref.current) return
-      if (!ref.current.contains(e.target as Node)) setOpen(false)
+      if (!ref.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
     }
-    document.addEventListener('click', onDoc)
-    return () => document.removeEventListener('click', onDoc)
+    document.addEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
   }, [])
 
+  function handleToggle() {
+    setOpen(value => !value)
+  }
+
   return (
-    <div className="relative" ref={ref}>
+    <div ref={ref} className="relative">
       <button
+        type="button"
         title={title}
-        onClick={()=> setOpen(o=>!o)}
-        className="w-10 h-10 rounded-lg bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 flex items-center justify-center"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={handleToggle}
+        className="flex h-10 w-10 items-center justify-center rounded-lg border border-slate-200 bg-white text-xl leading-none transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
       >
         ⋯
       </button>
       {open && (
-        <div className="absolute right-0 mt-2 w-44 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg py-1 z-20">
-          {items.map((it, i) => (
+        <div className="absolute right-0 mt-2 w-48 overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+          {items.map((item, index) => (
             <button
-              key={i}
-              onClick={()=>{ if (!it.disabled) { setOpen(false); it.onClick() } }}
-              disabled={it.disabled}
-              className="w-full text-left px-3 py-2 text-sm hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-50"
+              key={index}
+              type="button"
+              disabled={item.disabled}
+              onClick={() => {
+                if (item.disabled) return
+                setOpen(false)
+                item.onClick()
+              }}
+              className="block w-full px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-slate-200 dark:hover:bg-slate-800"
             >
-              {it.label}
+              {item.label}
             </button>
           ))}
         </div>

--- a/app/admin/ui/SkeletonRow.tsx
+++ b/app/admin/ui/SkeletonRow.tsx
@@ -3,9 +3,9 @@
 export default function SkeletonRow({ cols = 8 }: { cols?: number }) {
   return (
     <tr className="animate-pulse">
-      {Array.from({ length: cols }).map((_, i) => (
-        <td key={i} className="px-3 py-2">
-          <div className="h-4 w-full bg-slate-200 dark:bg-slate-700 rounded" />
+      {Array.from({ length: cols }).map((_, index) => (
+        <td key={index} className="px-3 py-2">
+          <div className="h-4 w-full rounded bg-slate-200 dark:bg-slate-700" />
         </td>
       ))}
     </tr>

--- a/app/admin/ui/Toasts.tsx
+++ b/app/admin/ui/Toasts.tsx
@@ -1,37 +1,47 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
+import { TOAST_EVENT, type ToastPayload } from '../hooks/useToasts'
 
-type Toast = { id: string; type: 'success'|'error'|'info'; message: string }
-const BUS = typeof window !== 'undefined' ? window : ({} as any)
-const EVT = 'app:toast'
+const DURATION = 3200
 
 export function Toaster() {
-  const [list, setList] = useState<Toast[]>([])
+  const [toasts, setToasts] = useState<ToastPayload[]>([])
 
   useEffect(() => {
-    function onToast(e: any) {
-      const t: Toast = e.detail
-      setList(prev => [...prev, t])
+    const bus = typeof window === 'undefined' ? null : window
+    if (!bus) return
+
+    function onToast(event: Event) {
+      const detail = (event as CustomEvent<ToastPayload>).detail
+      if (!detail) return
+      setToasts(prev => [...prev, detail])
       setTimeout(() => {
-        setList(prev => prev.filter(x => x.id !== t.id))
-      }, 3200)
+        setToasts(prev => prev.filter(item => item.id !== detail.id))
+      }, DURATION)
     }
-    BUS.addEventListener?.(EVT, onToast)
-    return () => BUS.removeEventListener?.(EVT, onToast)
+
+    bus.addEventListener(TOAST_EVENT, onToast as EventListener)
+    return () => bus.removeEventListener(TOAST_EVENT, onToast as EventListener)
   }, [])
 
+  if (toasts.length === 0) return null
+
   return (
-    <div className="fixed bottom-3 right-3 z-[100] space-y-2">
-      {list.map(t => (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-[100] flex w-full max-w-sm flex-col gap-2 sm:right-6">
+      {toasts.map(toast => (
         <div
-          key={t.id}
-          className={`min-w-[260px] max-w-[380px] rounded-xl px-3 py-2 shadow-lg border text-sm
-            ${t.type==='success' ? 'bg-emerald-50 border-emerald-200 text-emerald-900' :
-               t.type==='error' ? 'bg-rose-50 border-rose-200 text-rose-900' :
-                                  'bg-slate-50 border-slate-200 text-slate-900'}`}
+          key={toast.id}
+          role="status"
+          className={`pointer-events-auto rounded-xl border px-3 py-2 text-sm shadow-lg transition-all ${
+            toast.type === 'success'
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-900'
+              : toast.type === 'error'
+                ? 'border-rose-200 bg-rose-50 text-rose-900'
+                : 'border-slate-200 bg-white text-slate-900 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100'
+          }`}
         >
-          {t.message}
+          {toast.message}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- implement the reusable admin layout with sticky topbar, theme toggle fallback and toast host
- provide UI primitives (cards, buttons, badges, dropdown, skeleton) together with toast hook and gate/theme helpers
- add admin date, type and fetcher utilities plus a typed turnos data hook for filtered loading and KPI computation

## Testing
- `npm run lint` *(fails: repository has pre-existing lint errors across admin and api modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a16a2c54832b80465cc32acbed26